### PR TITLE
pkp/pkp-lib#1263 adapt test issue xml import file

### DIFF
--- a/tests/functional/issue.xml
+++ b/tests/functional/issue.xml
@@ -62,7 +62,6 @@
         <name locale="en_US">PDF</name>
         <seq>0</seq>
         <submission_file_ref id="48" revision="1"/>
-        <remote_url/>
       </article_galley>
     </article>
   </articles>


### PR DESCRIPTION
The "remote_url" element should be called "remote" -- as for all representations in all systems (OJS and OMP) and either remote element is used or submission_file_ref...