### PR TITLE
update working cdn for math-jax

### DIFF
--- a/lib/lens/index.html
+++ b/lib/lens/index.html
@@ -20,7 +20,7 @@
         styles: {".MathJax_Display": {padding: "0em 0em 0em 3em" },".MathJax_SVG_Display": {padding: "0em 0em 0em 3em" }}
       });
     </script>
-    <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 
     <script src='lens.js'></script>
     


### PR DESCRIPTION
Hi Alec,
Got in the browser  console, that the mathjax is retiring and updated the cdn accordingly.
https://www.mathjax.org/cdn-shutting-down/
Best wishes,
Dulip

