### PR TITLE
asmecher/lensGalley#36 add tests for text/xml mime type

### DIFF
--- a/LensGalleyPlugin.inc.php
+++ b/LensGalleyPlugin.inc.php
@@ -97,7 +97,7 @@ class LensGalleyPlugin extends GenericPlugin {
 		$galley =& $args[2];
 
 		$templateMgr = TemplateManager::getManager($request);
-		if ($galley && $galley->getFileType() == 'application/xml') {
+		if ($galley && in_array($galley->getFileType(), array('application/xml', 'text/xml'))) {
 			$templateMgr->assign(array(
 				'pluginLensPath' => $this->getLensPath($request),
 				'displayTemplatePath' => $this->getTemplateResource('display.tpl'),
@@ -156,7 +156,7 @@ class LensGalleyPlugin extends GenericPlugin {
 		$fileId =& $args[2];
 		$request = Application::get()->getRequest();
 
-		if ($galley && $galley->getFileType() == 'application/xml' && $galley->getFileId() == $fileId) {
+		if ($galley && in_array($galley->getFileType(), array('application/xml', 'text/xml')) && $galley->getFileId() == $fileId) {
 			if (!HookRegistry::call('LensGalleyPlugin::articleDownload', array($article,  &$galley, &$fileId))) {
 				$xmlContents = $this->_getXMLContents($request, $galley);
 				header('Content-Type: application/xml');


### PR DESCRIPTION
Hi everyone - the issue with images not being replaced is due to the mime type changing from application/xml to text/xml in new versions of PHP.  This pull request adds Alec's test from further up to the other methods so image replacement works again.